### PR TITLE
fix Artwork key bug

### DIFF
--- a/app/components/ArtworkGrid.tsx
+++ b/app/components/ArtworkGrid.tsx
@@ -16,6 +16,7 @@ const ArtworkGrid = ({ data }: ArtworkGridProps) => {
     const params = useSearchParams();
     const [selected, setSelected] = useState<ArtworkType>(
         {
+            id: 0,
             title: "",
             description: "",
             author: "",
@@ -34,6 +35,7 @@ const ArtworkGrid = ({ data }: ArtworkGridProps) => {
     useEffect(() => {
         setSelected(
             {
+                id: 0,
                 title: "",
                 description: "",
                 author: "",
@@ -56,7 +58,7 @@ const ArtworkGrid = ({ data }: ArtworkGridProps) => {
                 {
                     data.map((item) => {
                         return (
-                            <Artwork key={item.title} data={item} setSelected={setSelected} />
+                            <Artwork key={item.id} data={item} setSelected={setSelected} />
                         )
                     })
                 }

--- a/app/components/ImageDetail.tsx
+++ b/app/components/ImageDetail.tsx
@@ -66,6 +66,7 @@ const ImageDetail = ({ data, setSelected }: ImageDetailProps) => {
                         onClick={() => {
                             setSelected(
                                 {
+                                    id: 0,
                                     title: "",
                                     description: "",
                                     author: "",

--- a/types/ArtworkType.ts
+++ b/types/ArtworkType.ts
@@ -1,4 +1,5 @@
 export interface ArtworkType {
+    id: number,
     title: string,
     description: string,
     year_of_mfg: string,


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX18zPXPUCLqEbuDTpfuqmv9AAlaakK1YJg%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=-7a6xe9)

# 문제
가끔 키가 겹쳐서 일부 Artwork가 항상 왼쪽 위에 표시되는 경우가 발생

# 해결
Artwork의 key를 db의 id 값으로 수정